### PR TITLE
Richtext and markdown fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# x.y.z
+
+- Preserve `\` characters in `richtext`
+- Don't prefix `_` with extra `\` when rendering markdown
+
 # 0.4.62
 
 - Fix issue with number field default value

--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -34,5 +34,7 @@ export default (props) =>
         },
         props
       )}
-    />
+    >
+      {props.children.replace(/\\/g, '\\\\')}
+    </Markdown>
   ) : null;

--- a/src/RichText/index.js
+++ b/src/RichText/index.js
@@ -35,16 +35,18 @@ const RichText = isMobile
       );
     }
   : function RichText({ value, onChange }) {
-      const [editorValue, setEditorValue] = useState(() =>
-        RichTextEditor.createValueFromString(value ?? '', format)
-      );
+      const setState = () =>
+        RichTextEditor.createValueFromString(
+          value?.replace(/\\/g, '\\\\') ?? '',
+          format
+        );
+
+      const [editorValue, setEditorValue] = useState(setState);
 
       useEffect(() => {
         const prevValue = editorValue?.toString(format);
         if (value !== prevValue) {
-          setEditorValue(
-            RichTextEditor.createValueFromString(value ?? '', format)
-          );
+          setEditorValue(setState);
         }
         // This is only to track external value changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -58,7 +60,7 @@ const RichText = isMobile
               setEditorValue(editorValue);
             }, [])}
             onBlur={useCallback(
-              () => onChange(editorValue.toString(format)),
+              () => onChange(editorValue.toString(format).replace(/\\_/g, '_')),
               [editorValue, onChange]
             )}
           />


### PR DESCRIPTION
 - Preserve `\` characters in `richtext`
 - Don't prefix `_` with extra `\` when rendering markdown